### PR TITLE
Remove master key from repo and prevent its leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 !/tmp/storage/.keep
 
 /public/assets
+
+/config/master.key

--- a/config/master.key
+++ b/config/master.key
@@ -1,1 +1,0 @@
-372ece6023ca5d8b1ceec8cd086624c7


### PR DESCRIPTION
В этом реквесте я удалил файл с мастер-ключом из репо, и добавил его в гитигнор чтобы предотвратить эту проблему в будущем